### PR TITLE
feat: Adds resource attributes to achieve partial parity with Android SDK

### DIFF
--- a/Sources/PulseKit/PulseAttributes.swift
+++ b/Sources/PulseKit/PulseAttributes.swift
@@ -48,8 +48,4 @@ public enum PulseAttributes {
             return pulseType == network || pulseType.hasPrefix("\(network).")
         }
     }
-    
-    // Resource attributes for Android parity (not in official ResourceAttributes)
-    public static let appBuildId = "app.build_id"
-    public static let appBuildName = "app.build_name"
 }


### PR DESCRIPTION
## Summary
Adds Pulse-specific resource attributes to iOS SDK to achieve parity with Android SDK for cross-platform dashboard comparability.

## Changes

### Resource Attributes Added

1. **Application Attributes** (in `ApplicationResourceProvider`):
   - `app.build_id`: CFBundleVersion from Bundle.main
   - `app.build_name`: "version_build" format (e.g., "1.0_1") to match Android's `${versionName}_${versionCode}` format

2. **Device Attributes** (in `DeviceResourceProvider`):
   - `device.manufacturer`: "Apple" (using official `ResourceAttributes.deviceManufacturer`)
   - `device.model.name`: User-friendly model name from `UIDevice.current.model` (using official `ResourceAttributes.deviceModelName`)


## Android Parity

| Android Attribute | iOS Equivalent | Status |
|------------------|----------------|--------|
| `app.build_id` | `CFBundleVersion` | ✅ Added |
| `app.build_name` | `"${CFBundleShortVersionString}_${CFBundleVersion}"` | ✅ Added |
| `device.manufacturer` | `"Apple"` | ✅ Added |
| `device.model.name` | `UIDevice.current.model` | ✅ Added |
